### PR TITLE
Fix error when using Symfony annotations on controller action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
   allow_failures:
     - php: 7.0
-    - env: SYMFONY_VERSION=3.0.*
 
 before_script:
   - pecl -q install xhprof-beta && echo "extension=xhprof.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`

--- a/Notify/Mailer.php
+++ b/Notify/Mailer.php
@@ -3,6 +3,7 @@
 namespace Socloz\MonitoringBundle\Notify;
 
 use Psr\Log\LoggerInterface;
+use Socloz\MonitoringBundle\Transformer\MailerTransformer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Templating\EngineInterface;
 
@@ -24,6 +25,11 @@ class Mailer
     protected $templating;
 
     /**
+     * @var MailerTransformer
+     */
+    protected $mailerTransformer;
+
+    /**
      * @var string
      */
     protected $from;
@@ -34,14 +40,15 @@ class Mailer
     protected $to;
 
     /**
-     * @param \Swift_Mailer   $mailer
-     * @param EngineInterface $templating
-     * @param LoggerInterface $logger
-     * @param string          $from
-     * @param string          $to
-     * @param boolean         $enabled
+     * @param \Swift_Mailer     $mailer
+     * @param EngineInterface   $templating
+     * @param LoggerInterface   $logger
+     * @param MailerTransformer $requestTransformer
+     * @param string            $from
+     * @param string            $to
+     * @param boolean           $enabled
      */
-    public function __construct(\Swift_Mailer $mailer, EngineInterface $templating, LoggerInterface $logger, $from, $to, $enabled)
+    public function __construct(\Swift_Mailer $mailer, EngineInterface $templating, LoggerInterface $logger, MailerTransformer $requestTransformer, $from, $to, $enabled)
     {
         $this->mailer = $mailer;
         $this->templating = $templating;
@@ -49,6 +56,7 @@ class Mailer
         $this->to = $to;
         $this->enabled = $enabled;
         $this->logger = $logger;
+        $this->mailerTransformer = $requestTransformer;
     }
 
     /**
@@ -83,8 +91,8 @@ class Mailer
                         'exception' => $exception,
                         'exception_class' => \get_class($exception),
                         'request_headers' => $request->server->getHeaders(),
-                        'request_attributes' => $request->attributes->all(),
-                        'server_params' => $request->server->all(),
+                        'request_attributes' => $this->mailerTransformer->transform($request->attributes->all()),
+                        'server_params' => $this->mailerTransformer->transform($request->server->all()),
                     )
                 )
             );

--- a/Resources/config/mailer.xml
+++ b/Resources/config/mailer.xml
@@ -6,13 +6,17 @@
 
     <parameters>
         <parameter key="socloz_monitoring.mailer.class">Socloz\MonitoringBundle\Notify\Mailer</parameter>
+        <parameter key="socloz_monitoring.mailer_transformer.class">Socloz\MonitoringBundle\Transformer\MailerTransformer</parameter>
     </parameters>
     
     <services>
+        <service id="socloz_monitoring.mailer_transformer" class="%socloz_monitoring.mailer_transformer.class%" >
+        </service>
         <service id="socloz_monitoring.mailer" class="%socloz_monitoring.mailer.class%" >
             <argument type="service" id="mailer" on-invalid="null" />
             <argument type="service" id="templating" on-invalid="null" />
             <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="socloz_monitoring.mailer_transformer" />
             <argument>%socloz_monitoring.mailer.from%</argument>
             <argument>%socloz_monitoring.mailer.to%</argument>
             <argument>%socloz_monitoring.mailer.enable%</argument>

--- a/Resources/views/Notify/exception.html.twig
+++ b/Resources/views/Notify/exception.html.twig
@@ -1,3 +1,31 @@
+{% macro renderIterable(var) %}
+    <table border="1">
+        {% for param, value in var if value is not empty %}
+            <tr>
+                <td>{{ param }}</td>
+                <td>{{ value is iterable ? value|json_encode : value }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endmacro %}
+
+{% macro renderValue(var) %}
+    {% if var is iterable %}
+        {% for key, value in var if value is not empty %}
+            <strong>{{ key }}</strong>:
+            {% if value is iterable %}
+                {{ _self.renderIterable(value) }}
+            {% else %}
+                {{ value }}
+                <br />
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {{ var }}
+        <br />
+    {% endif %}
+{% endmacro %}
+
 <h2>{{ exception_class }} : {{ exception.message }}</h2>
 
 <h3>Information:</h3>
@@ -7,23 +35,8 @@
 <strong>Uri: </strong> {{ request.uri }} <br />
 
 {% if request_attributes %}
-<h3>Request Attributes:</h3>
-{% for key, header in request_attributes %}
-    <strong>{{ key }}</strong>:
-    {% if header is iterable %}
-        <table border="1">
-        {% for param, value in header %}
-            <tr>
-                <td>{{ param }}</td>
-                <td>{{ value}}</td>
-            </tr>
-        {% endfor %}
-        </table>
-    {% else %}
-        {{ header }}
-    {% endif %}
-    <br />
-{% endfor %}
+    <h3>Request Attributes:</h3>
+    {{ _self.renderValue(request_attributes) }}
 {% endif %}
 
 <h3>Stack trace:</h3>
@@ -57,11 +70,7 @@
 {% endif %}
 
 <h3>Request Headers:</h3>
-{% for key, header in request_headers %}
-    <strong>{{ key }}</strong>: {{ header }}<br />
-{% endfor %}
+{{ _self.renderValue(request_headers) }}
 
 <h3>Request Server Parameters:</h3>
-{% for key, header in server_params %}
-    <strong>{{ key }}</strong>: {{ header }}<br />
-{% endfor %}
+{{ _self.renderValue(server_params) }}

--- a/Tests/Transformer/MailerTransformerTest.php
+++ b/Tests/Transformer/MailerTransformerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Socloz\MonitoringBundle\Tests\Transformer;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Socloz\MonitoringBundle\Transformer\MailerTransformer;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class MailerTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTransformIterableWithTraversableObject()
+    {
+        $transformer = new MailerTransformer();
+
+        $traversableObject = new ParameterBag(array('foo' => 'bar', 'john' => 'doe'));
+        $expected = array('foo' => 'bar', 'john' => 'doe');
+
+        $this->assertEquals($transformer->transform($traversableObject), $expected);
+    }
+
+    public function testTransformIterableWithArray()
+    {
+        $transformer = new MailerTransformer();
+
+        $array = array('foo' => 'bar', 'john' => 'doe');
+
+        $this->assertEquals($transformer->transform($array), $array);
+    }
+
+    public function testTransformBoolean()
+    {
+        $transformer = new MailerTransformer();
+
+        $this->assertEquals($transformer->transform(true), 'Yes');
+        $this->assertEquals($transformer->transform(false), 'No');
+    }
+
+    public function testTransformCacheAnnotation()
+    {
+        $transformer = new MailerTransformer();
+
+        $cache = new Cache(array(
+            'etag' => $hash = md5('etag'),
+            'expires' => '+1 day',
+            'maxage' => 3600,
+            'smaxage' => 1800,
+            'public' => true,
+            'vary' => array('foo' => 'bar')
+        ));
+
+        $expected = array(
+            'expires' => '+1 day',
+            'maxage' => 3600,
+            'smaxage' => 1800,
+            'public' => 'Yes',
+            'vary' => array('foo' => 'bar'),
+            'etag' => $hash,
+            'lastModified' => null,
+        );
+
+        $this->assertEquals($transformer->transform($cache), $expected);
+    }
+
+    public function testTransformMethodAnnotation()
+    {
+        $transformer = new MailerTransformer();
+
+        $method = new Method(array('methods' => 'GET'));
+        $this->assertEquals($transformer->transform($method), 'GET');
+
+        $method = new Method(array('methods' => array('GET')));
+        $this->assertEquals($transformer->transform($method), 'GET');
+
+        $method = new Method(array('methods' => array('GET', 'POST')));
+        $this->assertEquals($transformer->transform($method), 'GET, POST');
+    }
+
+    public function testTransformParamConverter()
+    {
+        $transformer = new MailerTransformer();
+
+        $paramConverter = new ParamConverter(array(
+            'name' => 'post',
+            'class' => 'AcmeBlogBundle:Post',
+        ));
+
+        $expected = array(
+            'name' => 'post',
+            'class' => 'AcmeBlogBundle:Post',
+            'options' => array(),
+            'optional' => 'No',
+            'converter' => null,
+        );
+
+        $this->assertEquals($transformer->transform($paramConverter), $expected);
+    }
+
+    public function testTransformSecurity()
+    {
+        $transformer = new MailerTransformer();
+
+        $security = new Security(array('expression' => 'symfony_expression'));
+
+        $this->assertEquals($transformer->transform($security), 'symfony_expression');
+    }
+
+    public function testTransformTemplate()
+    {
+        $transformer = new MailerTransformer();
+
+        $template = new Template(array(
+            'template' => 'AcmeBlogBundle:Default:template.html.twig',
+        ));
+
+        $expected = array(
+            'template' => 'AcmeBlogBundle:Default:template.html.twig',
+            'engine' => 'twig',
+            'vars' => array(),
+            'streamable' => 'No',
+        );
+
+        $this->assertEquals($transformer->transform($template), $expected);
+    }
+
+    public function testTransformWithObject()
+    {
+        $transformer = new MailerTransformer();
+
+        $object = new \StdClass;
+        $object->test = 'hello';
+
+        $this->assertEquals($transformer->transform($object), 'stdClass');
+    }
+}

--- a/Transformer/MailerTransformer.php
+++ b/Transformer/MailerTransformer.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Socloz\MonitoringBundle\Transformer;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class MailerTransformer
+{
+    /**
+     * Transform a value into its array value
+     *
+     * @param mixed $value
+     * @return array|string
+     */
+    public function transform($value)
+    {
+        if ($value instanceof \Traversable || is_array($value)) {
+            return $this->transformIterable($value);
+        }
+
+        if (is_bool($value)) {
+            return $this->transformBoolean($value);
+        }
+
+        if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            return $value;
+        }
+
+        if ($value instanceof Cache) {
+            return $this->transformCacheAnnotation($value);
+        }
+
+        if ($value instanceof Method) {
+            return $this->transformMethodAnnotation($value);
+        }
+
+        if ($value instanceof ParamConverter) {
+            return $this->transformParamConverter($value);
+        }
+
+        if ($value instanceof Security) {
+            return $this->transformSecurity($value);
+        }
+
+        if ($value instanceof Template) {
+            return $this->transformTemplate($value);
+        }
+
+        return get_class($value);
+    }
+
+    /**
+     * Transform iterable value into array
+     *
+     * @param \Traversable|array $value
+     * @return array
+     */
+    protected function transformIterable($value)
+    {
+        $params = array();
+
+        foreach ($value as $key => $val) {
+            if (!empty($val)) {
+                $params[$key] = $this->transform($val);
+            }
+        }
+
+        return $params;
+    }
+
+    /**
+     * Transform boolean value into string
+     *
+     * @param bool $value
+     * @return string
+     */
+    protected function transformBoolean($value)
+    {
+        return $value ? 'Yes' : 'No';
+    }
+
+    /**
+     * Transform Cache Symfony annotation into equivalent array
+     *
+     * @param Cache $cache
+     * @return array
+     */
+    protected function transformCacheAnnotation(Cache $cache)
+    {
+        return array(
+            'expires' => $cache->getExpires(),
+            'maxage' => $cache->getMaxAge(),
+            'smaxage' => $cache->getSMaxAge(),
+            'public' => $this->transformBoolean($cache->isPublic()),
+            'vary' => $cache->getVary(),
+            'lastModified' => $cache->getLastModified(),
+            'etag' => $cache->getETag(),
+        );
+    }
+
+    /**
+     * Transform Method Symfony annotation into string equivalent
+     *
+     * @param Method $method
+     * @return string
+     */
+    protected function transformMethodAnnotation(Method $method)
+    {
+        return implode(', ', $method->getMethods());
+    }
+
+    protected function transformParamConverter(ParamConverter $paramConverter)
+    {
+        return array(
+            'name' => $paramConverter->getName(),
+            'class' => $paramConverter->getClass(),
+            'options' => $this->transform($paramConverter->getOptions()),
+            'optional' => $this->transformBoolean($paramConverter->isOptional()),
+            'converter' => $paramConverter->getConverter(),
+        );
+    }
+
+    /**
+     * Transform Security Symfony annotation into string equivalent
+     *
+     * @param Security $security
+     * @return mixed
+     */
+    protected function transformSecurity(Security $security)
+    {
+        return $security->getExpression();
+    }
+
+    /**
+     * Transform Template Symfony annotation into array equivalent
+     *
+     * @param Template $template
+     * @return array
+     */
+    protected function transformTemplate(Template $template)
+    {
+        return array(
+            'template' => $template->getTemplate(),
+            'engine' => $template->getEngine(),
+            'vars' => $this->transform($template->getVars()),
+            'streamable' => $this->transformBoolean($template->isStreamable()),
+        );
+    }
+}


### PR DESCRIPTION
When using the mailer, the template render `attributes` property of the `Request`. This property can contain object if we use some annotation of the SensionExtraFrameworkBundle which cause an exception on template rendering.

Example :

```php
/**
 * @Route("/", name="homepage")
 * @Method({"GET", "POST"})
 */
public function indexAction(Request $request)
{
    return $this->render('default/index.html.twig', [
        'base_dir' => realpath($this->getParameter('kernel.root_dir').'/..'),
    ]);
}
```

This PR is for fixing that issue. It introduce a `MailerTransform` to convert each properties to an array or a scalar value.